### PR TITLE
added new line spacings before usage info

### DIFF
--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -1334,7 +1334,7 @@ end
 function GSE.ExportSequenceWLMFormat(sequence, sequencename)
     local returnstring = "<strong>".. sequencename .."</strong>\n<em>Talents</em> " .. (GSE.isEmpty(sequence.Talents) and "?,?,?,?,?,?,?" or sequence.Talents) .. "\n\n"
     if not GSE.isEmpty(sequence.Help) then
-      returnstring = "<em>Usage Information</em>\n" .. sequence.Help .. "\n\n"
+      returnstring = "\n\n<em>Usage Information</em>\n" .. sequence.Help .. "\n\n"
     end
     returnstring = returnstring .. "This macro contains " .. (table.getn(sequence.MacroVersions) > 1 and table.getn(sequence.MacroVersions) .. "macro versions. " or "1 macro version. ") .. string.format(L["This Sequence was exported from GSE %s."], GSE.formatModVersion(GSE.VersionString)) .. "\n\n"
     if (table.getn(sequence.MacroVersions) > 1) then


### PR DESCRIPTION
The export string was joining at the end with Usage Information when pasted on the website, added a few lines to prevent that.