### PR TITLE
Fix broken links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 About this Repository
 ===================================
-This repository is a work in progress.  Code here may be broken at any point in time.  This contains the source code for GnomeSequencer-Enahnced in its raw form.  Libraries are referred to but are not present in this repository.  While releases are tagged as releases, alpha builds are released via http://wow.curseforge.com/addons/gnomesequencer-enhanced/  
+This repository is a work in progress.  Code here may be broken at any point in time.  This contains the source code for GnomeSequencer-Enahnced in its raw form.  Libraries are referred to but are not present in this repository.  While releases are tagged as releases, alpha builds are released via https://www.curseforge.com/wow/addons/gse-gnome-sequencer-enhanced-advanced-macros  
 
-To use this locally straight from this source you must install https://mods.curse.com/addons/wow/ace3 as a standalone mod.  You must also install all the libraries listed in the .pkgmeta in the lib folder and set an exclusion in your .git file.  If you are not familiar with Git and Curse's build management system don't download the releases from here and expect them to work.  Grab the full package from Curseforge.
+To use this locally straight from this source you must install https://www.curseforge.com/wow/addons/ace3 as a standalone mod.  You must also install all the libraries listed in the .pkgmeta in the lib folder and set an exclusion in your .git file.  If you are not familiar with Git and Curse's build management system don't download the releases from here and expect them to work.  Grab the full package from Curseforge.
 
 Current Build Status
 ===================================


### PR DESCRIPTION
It says module disabled for the first link, so I changed it to the main URL. But it could be that there is something else I am not aware of.

But definitely ace 3 points to the right page without needing to use the redirect.